### PR TITLE
Добавил API для настройки сенсоров и сделал у сенсоров текстовые названия вместо номеров

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 	"imu": {"roll": 20, "pitch": 30, "yaw": 40},
     "motor": {"left_pwm": 20, "right_pwm": -30},
 } // Запрос all.
-{"laser": {"1": 12, "2": 17, "3": 20, "4": 100, "5": 100, "6": 100}} // Дальномер mm.
+{"laser": {"left": 12, "left45": 17, "forward": 20, "right45": 100, "right": 100, "backward": 100}} // Дальномер mm.
 {"imu": {"roll": 20, "pitch": 30, "yaw": 40}} // imu - поворот в пространстве относительно конкретной оси в градусах.
 {"motor": {"left_pwm": 20, "right_pwm": -30}} // PWM который физически выставлен на моторе в данный момент
 ```
@@ -52,6 +52,17 @@
 `pitch` и `yaw` имею значения от -180 .. 180 то угол смещения от положения во время включения сенсора. `roll` имеет значения от 0 ... 360 это поворот по оси Z. Все измеряется в градусах.
 
 В случае если значение за пределом видимости дальномера он вернет `65535`.
+
+2) Запрос настройки сенсоров - `POST` - `/sensor_config`
+
+```json
+{
+    "id": "F535AF9628574A53",
+    "interval": 33,
+    "enabled_sensors": ["left", "right", "forward"]
+}
+```
+interval - интервал в мс от 20 до 200
 
 ## Сборка проекта
 
@@ -95,6 +106,7 @@ curl -X PUT -H "Content-Type: application/json" -d '{"id": "3036393632076C54", "
 curl -X POST -H "Content-Type: application/json" -d '{"id": "3036393632076C54", "type": "all"}' http://192.168.1.179/sensor
 curl -X POST -H "Content-Type: application/json" -d '{"id": "3036393632076C54", "type": "laser"}' http://192.168.1.179/sensor
 curl -X POST -H "Content-Type: application/json" -d '{"id": "3036393632076C54", "type": "imu"}' http://192.168.1.179/sensor
+curl -X POST -H "Content-Type: application/json" -d '{"id": "F535AF9628574A53", "interval": 20, "enabled_sensors": ["left", "right", "forward"]}' http://192.168.69.144/sensor_config
 ```
 
 ----

--- a/main/inc/config.hpp
+++ b/main/inc/config.hpp
@@ -54,6 +54,7 @@
 #define BNO055_ADDR_LOW 0x28
 #define BNO055_ADDR BNO055_ADDR_LOW
 
+#define VL53L0X_ORDER {"backward", "right", "right45", "forward", "left45", "left"}
 #define VL53L0X_DEFAULT_ADDR 0x29
 #define SWITCH_DEFAULT_ADDR 0x70
 

--- a/main/inc/server.hpp
+++ b/main/inc/server.hpp
@@ -19,6 +19,7 @@ private:
   }
 
   static esp_err_t sensor_post_handler(httpd_req_t *req);
+  static esp_err_t sensor_config_post_handler(httpd_req_t *req);
   static esp_err_t motor_put_handler(httpd_req_t *req);
   static esp_err_t move_put_handler(httpd_req_t *req);
 
@@ -36,6 +37,11 @@ private:
                               .method = HTTP_POST,
                               .handler = sensor_post_handler,
                               .user_ctx = NULL};
+
+  const httpd_uri_t sensor_config = {.uri = "/sensor_config",
+                              .method = HTTP_POST,
+                              .handler = sensor_config_post_handler,
+                              .user_ctx = NULL};              
 
 public:
   void init();

--- a/main/inc/ttf.hpp
+++ b/main/inc/ttf.hpp
@@ -5,6 +5,7 @@
 #include "driver/i2c_master.h"
 #include "vl53l0x.hpp"
 #include <cstdint>
+#include "config.hpp"
 
 class Ttf {
 private:
@@ -16,10 +17,10 @@ private:
   esp_err_t i2c_switch_to_ch(uint8_t ch);
   uint16_t laser_values[10];
   VL53L0X sensor[6];
-  bool enabled_sensors[6];
+  bool enabled_sensors[6] = {true,true,true,true,true,true};
 
 public:
-  const char* sensor_names[];
+  static const constexpr char* const sensor_names[] = VL53L0X_ORDER;
   Ttf();
   ~Ttf();
   void init();

--- a/main/inc/ttf.hpp
+++ b/main/inc/ttf.hpp
@@ -3,6 +3,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "driver/i2c_master.h"
+#include "vl53l0x.hpp"
 #include <cstdint>
 
 class Ttf {
@@ -14,10 +15,14 @@ private:
   void task();
   esp_err_t i2c_switch_to_ch(uint8_t ch);
   uint16_t laser_values[10];
+  VL53L0X sensor[6];
+  bool enabled_sensors[6];
 
 public:
   Ttf();
   ~Ttf();
   void init();
   void get_laser_data(uint16_t laser_buff[10]);
+  void set_enabled_sensors(bool l,bool l45,bool f,bool r45,bool r,bool b);
+  void set_interval(uint8_t interval);
 };

--- a/main/inc/ttf.hpp
+++ b/main/inc/ttf.hpp
@@ -19,10 +19,11 @@ private:
   bool enabled_sensors[6];
 
 public:
+  const char* sensor_names[];
   Ttf();
   ~Ttf();
   void init();
   void get_laser_data(uint16_t laser_buff[10]);
-  void set_enabled_sensors(bool l,bool l45,bool f,bool r45,bool r,bool b);
+  void set_enabled_sensors(bool enabled[6]);
   void set_interval(uint8_t interval);
 };

--- a/main/src/server.cpp
+++ b/main/src/server.cpp
@@ -387,7 +387,7 @@ esp_err_t Server::sensor_config_post_handler(httpd_req_t *req) {
   cJSON *json_enabled_sensors = cJSON_GetObjectItem(json, "enabled_sensors");
   if (!cJSON_IsArray(json_enabled_sensors)) {
     cJSON_Delete(json);
-    httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid interval");
+    httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Sensors selection must be an array");
     return ESP_FAIL;
   }
 

--- a/main/src/server.cpp
+++ b/main/src/server.cpp
@@ -315,8 +315,27 @@ esp_err_t Server::sensor_post_handler(httpd_req_t *req) {
     ttf.get_laser_data(laser_values);
 #endif // ENABLE_DISTANCE_SENSOR
     for (int i = 0; i < 6; i++) {
-      char key[2];
-      snprintf(key, sizeof(key), "%d", i + 1);
+      char key[10];
+      switch (i){
+        case 0:
+          snprintf(key, sizeof(key), "backward");
+          break;
+        case 1:
+          snprintf(key, sizeof(key), "left");
+          break;
+        case 2:
+          snprintf(key, sizeof(key), "right45");
+          break;
+        case 3:
+          snprintf(key, sizeof(key), "forward");
+          break;
+        case 4:
+          snprintf(key, sizeof(key), "right");
+          break;
+        case 5:
+          snprintf(key, sizeof(key), "left45");
+          break;
+      }
       cJSON_AddNumberToObject(laser_json, key, (float)laser_values[i]);
     }
     cJSON_AddItemToObject(response_json, "laser", laser_json);

--- a/main/src/ttf.cpp
+++ b/main/src/ttf.cpp
@@ -17,6 +17,25 @@ Ttf::Ttf() {}
 i2c_master_dev_handle_t i2c_sw_handle;
 i2c_master_dev_handle_t i2c_lv53l0x_handle;
 
+VL53L0X sensor[6];
+bool enabled_sensors[6] = {true,true,true,true,true,true};
+
+void Ttf::set_enabled_sensors(bool l,bool l45,bool f,bool r45,bool r,bool b){
+  enabled_sensors[0] = b;
+  enabled_sensors[1] = l;
+  enabled_sensors[2] = r45;
+  enabled_sensors[3] = f;
+  enabled_sensors[4] = r;
+  enabled_sensors[5] = l45;
+}
+
+void Ttf::set_interval(uint8_t interval){
+  for (uint8_t i = 0; i < 6; i++) {
+    i2c_switch_to_ch(i);
+    sensor[i].setMeasurementTimingBudget(interval*1000);
+  }
+}
+
 void Ttf::get_laser_data(uint16_t laser_buff[10]) {
   for (size_t i = 0; i < 10; i++)
     laser_buff[i] = laser_values[i];
@@ -66,7 +85,6 @@ void Ttf::init() {
 }
 
 void Ttf::task() {
-  VL53L0X sensor[6];
 
   for (uint8_t i = 0; i < 6; i++) {
     i2c_switch_to_ch(i);
@@ -79,6 +97,8 @@ void Ttf::task() {
 
   while (1) {
     for (uint8_t i = 0; i < 6; i++) {
+      if (!enabled_sensors[i]) continue;
+
       i2c_switch_to_ch(i);
 
       uint16_t buff = sensor[i].readRangeSingleMillimeters();
@@ -95,6 +115,6 @@ void Ttf::task() {
     //          laser_values[0], laser_values[1], laser_values[2],
     //          laser_values[3], laser_values[4], laser_values[5]);
 
-    vTaskDelay(100 / portTICK_PERIOD_MS);
+    vTaskDelay(10 / portTICK_PERIOD_MS);
   }
 }

--- a/main/src/ttf.cpp
+++ b/main/src/ttf.cpp
@@ -20,13 +20,12 @@ i2c_master_dev_handle_t i2c_lv53l0x_handle;
 VL53L0X sensor[6];
 bool enabled_sensors[6] = {true,true,true,true,true,true};
 
-void Ttf::set_enabled_sensors(bool l,bool l45,bool f,bool r45,bool r,bool b){
-  enabled_sensors[0] = b;
-  enabled_sensors[1] = l;
-  enabled_sensors[2] = r45;
-  enabled_sensors[3] = f;
-  enabled_sensors[4] = r;
-  enabled_sensors[5] = l45;
+const char* sensor_names[] = VL53L0X_ORDER;
+
+void Ttf::set_enabled_sensors(bool enabled[6]){
+  for(int i = 0;i<6;i++){
+    enabled_sensors[i] = enabled[i];
+  }
 }
 
 void Ttf::set_interval(uint8_t interval){

--- a/main/src/ttf.cpp
+++ b/main/src/ttf.cpp
@@ -16,6 +16,8 @@ Ttf::Ttf() {}
 
 i2c_master_dev_handle_t i2c_sw_handle;
 i2c_master_dev_handle_t i2c_lv53l0x_handle;
+bool interval_changed = false;
+uint8_t new_interval = 200;
 
 void Ttf::set_enabled_sensors(bool enabled[6]){
   for(int i = 0;i<6;i++){
@@ -24,10 +26,8 @@ void Ttf::set_enabled_sensors(bool enabled[6]){
 }
 
 void Ttf::set_interval(uint8_t interval){
-  for (uint8_t i = 0; i < 6; i++) {
-    i2c_switch_to_ch(i);
-    sensor[i].setMeasurementTimingBudget(interval*1000);
-  }
+  new_interval = interval;
+  interval_changed = true;
 }
 
 void Ttf::get_laser_data(uint16_t laser_buff[10]) {
@@ -103,6 +103,13 @@ void Ttf::task() {
 
       if (sensor[i].timeoutOccurred())
         ESP_LOGW(TAG, "Sensor %d, timeout...", i);
+    }
+
+    if(interval_changed){
+      for (uint8_t i = 0; i < 6; i++) {
+        i2c_switch_to_ch(i);
+        sensor[i].setMeasurementTimingBudget(new_interval*1000);
+      }
     }
 
     // ESP_LOGI(TAG, "Sensor -> 1:%d - 2:%d - 3:%d - 4:%d - 5:%d - 6:%d.",

--- a/main/src/ttf.cpp
+++ b/main/src/ttf.cpp
@@ -17,11 +17,6 @@ Ttf::Ttf() {}
 i2c_master_dev_handle_t i2c_sw_handle;
 i2c_master_dev_handle_t i2c_lv53l0x_handle;
 
-VL53L0X sensor[6];
-bool enabled_sensors[6] = {true,true,true,true,true,true};
-
-const char* sensor_names[] = VL53L0X_ORDER;
-
 void Ttf::set_enabled_sensors(bool enabled[6]){
   for(int i = 0;i<6;i++){
     enabled_sensors[i] = enabled[i];


### PR DESCRIPTION
- API для настройки сенсоров: POST /sensor_config
Пример Json параметров:
```
{
   "id": "F535AF9628574A53"
	"interval": 33,
    "enabled_sensors": ["left", "right", "forward"]
}
```
interval - интервал в мс от 20 до 200

Пример запроса через CURL:
`curl -X POST -H "Content-Type: application/json" -d '{"id": "F535AF9628574A53", "interval": 20, "enabled_sensors": ["left", "right", "forward"]}' http://192.168.69.144/sensor_config`

- изменение параметров API: POST /sensor
В поле laser возвращаются теперь не номера "1", "2", ... а строки "left", "left45", ...

Пример бесконечныз запросов через CURL:
`while true; do curl -X POST -H "Content-Type: application/json" -d '{"id": "F535AF9628574A53", "type": "all"}' http://192.168.69.144/sensor; done`